### PR TITLE
fix: prevent further game play by maxMovementsAchievement and maxTime…

### DIFF
--- a/js/board.js
+++ b/js/board.js
@@ -121,10 +121,14 @@ define(["js/properties", "js/sound", "js/squareImages", "js/info"], (properties,
     Board.prototype.clicked = event => {
         if (level.filledSquares() < level.squaresToFill) {
             if (event.target.className.startsWith("squareImage")) {
-                if (level.pinSelected) {
-                    level.board.pinSquare(event.target.id);
+                if (info.movementTotal() < level.maxMovementsAchievement && info.timeTotal() < level.maxTimeAchievement) {
+                    if (level.pinSelected) {
+                        level.board.pinSquare(event.target.id);
+                    } else {
+                        level.board.turnImage(event.target.id);
+                    }
                 } else {
-                    level.board.turnImage(event.target.id);
+                    sound.play(sound.FORBIDDEN);
                 }
             }
         }
@@ -143,7 +147,7 @@ define(["js/properties", "js/sound", "js/squareImages", "js/info"], (properties,
     }   
 
     Board.prototype.mouseover = event => {    
-        if (level.filledSquares() < level.squaresToFill) {  
+        if (level.filledSquares() < level.squaresToFill && info.movementTotal() < level.maxMovementsAchievement && info.timeTotal() < level.maxTimeAchievement) {  
             if (event.target.className.startsWith("squareImage")) { 
                 const squarePosition = squareImages.getPosition(event.target.id); 
                 let mouseOveredSquare = level.board.squares[squarePosition[0]][squarePosition[1]];  

--- a/js/info.js
+++ b/js/info.js
@@ -40,8 +40,12 @@ define([], () => {
     };
 
     const regenerate = () => {
-        ++totalSeconds;
-        document.getElementById("info-text").innerText = getInfo()
+        if (totalSeconds < level.maxTimeAchievement) {
+            ++totalSeconds;
+            document.getElementById("info-text").innerText = getInfo();
+        } else {
+            window.clearInterval(intervalId);
+        }
     };
 
     return {
@@ -69,6 +73,9 @@ define([], () => {
         },
         movementTotal: function movementTotal() {
             return movements;
-        }
+        },
+        timeTotal: function timeTotal() {
+            return totalSeconds;
+        },
     };
 });

--- a/test/allTests.js
+++ b/test/allTests.js
@@ -1,5 +1,6 @@
 import "babel-register";
 import "./levelsTest.js";
 import "./infoTest.js";
+import "./boardTest.js";
 import "./squareImagesTest.js";
 import "./test.js";

--- a/test/boardTest.js
+++ b/test/boardTest.js
@@ -1,0 +1,90 @@
+import test from "tape";
+import requirejs from "requirejs";
+
+test("board.js movement achievement tests", (assert) => {
+	requirejs.config({
+		baseUrl: './'
+	});
+	requirejs(["js/board", "js/info", "js/sound"], function (boardModule, info, sound) {
+		
+		assert.ok(info, "info module should be loaded");
+		assert.ok(sound, "sound module should be loaded");
+		assert.ok(boardModule, "board module should be loaded");
+		
+		const oldDocument = global.document;
+		const oldWindow = global.window;
+		const oldLevel = global.level;
+		const oldAudio = global.Audio;
+
+		let soundPlayed = null;
+
+		global.document = {
+			createElement: () => ({ 
+				appendChild: () => {}, 
+				className: "", 
+				id: "", 
+				setAttribute: () => {},
+				childNodes: []
+			}),
+			getElementById: () => ({ 
+				innerText: "", 
+				insertBefore: () => {},
+				childNodes: [{}, {}],
+				appendChild: () => {}
+			})
+		};
+		global.window = {
+			setInterval: () => 123,
+			clearInterval: () => {}
+		};
+		global.setInterval = global.window.setInterval;
+		global.clearInterval = global.window.clearInterval;
+		global.Audio = class {
+			constructor() {}
+			play() {}
+		};
+
+		global.level = {
+			filledSquares: () => 0,
+			squaresToFill: 10,
+			maxMovementsAchievement: 1,
+			maxTimeAchievement: 100,
+			pinSelected: false,
+			board: {
+				pinSquare: () => { assert.fail("Should not pin square"); },
+				turnImage: () => { assert.fail("Should not turn image"); }
+			}
+		};
+
+		const originalSoundPlay = sound.play;
+		sound.play = (id) => {
+			soundPlayed = id;
+		};
+
+		const board = boardModule.createEmptyBoard();
+
+		info.generateInfo(1, 1);
+		info.addMovement();
+		
+		const mockEvent = {
+			target: {
+				className: "squareImage",
+				id: "imageRow0Column0"
+			}
+		};
+
+		board.clicked(mockEvent);
+
+		assert.equal(soundPlayed, sound.FORBIDDEN, "FORBIDDEN sound should be played when movement limit is reached");
+
+		info.stop();
+
+		sound.play = originalSoundPlay;
+		global.document = oldDocument;
+		global.window = oldWindow;
+		global.level = oldLevel;
+		global.Audio = oldAudio;
+
+		assert.end();
+	});
+});

--- a/test/infoTest.js
+++ b/test/infoTest.js
@@ -84,6 +84,62 @@ test("info.js tests", (assert) => {
 			'Should have 1 movement'
 		);
 
-		assert.end();
+		// timeTotal
+		assert.ok(
+			info.hasOwnProperty("timeTotal"),
+			"Asserts that info.js has a property called timeTotal"
+		);
+		assert.equal(
+			typeof info.timeTotal,
+			"function",
+			"Asserts that the value type of 'timeTotal' property is a function"
+		);
+		assert.equal(
+			typeof info.timeTotal(),
+			"number",
+			"Asserts that 'timeTotal()' function returns a value with number type"
+		);
+
+		// Time limit assertion
+		assert.equal(
+			info.timeTotal(),
+			0,
+			'Should start with 0 seconds for time limit tracking'
+		);
+
+		const oldDocument = global.document;
+		const oldWindow = global.window;
+		const oldInterval = global.setInterval;
+		const oldClearInterval = global.clearInterval;
+
+		global.document = {
+			createElement: () => ({ appendChild: () => {}, className: "", id: "" }),
+			getElementById: () => ({ innerText: "" })
+		};
+		global.window = {
+			setInterval: setInterval,
+			clearInterval: clearInterval
+		};
+		global.setInterval = setInterval;
+		global.clearInterval = clearInterval;
+
+		global.level = { maxTimeAchievement: 1 };
+		info.generateInfo(1, 19); 
+		
+		assert.equal(info.timeTotal(), 0, "Time should start at 0");
+		
+		setTimeout(() => {
+			assert.ok(info.timeTotal() <= 1, "Time should NOT exceed maxTimeAchievement (1)");
+
+			info.stop();
+
+			// Restore globals
+			global.document = oldDocument;
+			global.window = oldWindow;
+			global.setInterval = oldInterval;
+			global.clearInterval = oldClearInterval;
+
+			assert.end();
+		}, 2000);
 	});
 });


### PR DESCRIPTION
Closes #80

This PR was opened to prevent players for further game playing by `maxMovementsAchievement` and `maxTimeAchievement`.

The unit tests were also created for verifying the functionality of the PR.

The code was tested locally, and `npm run allTests` did not report any specific errors.